### PR TITLE
思い出機能にタグ機能を追加

### DIFF
--- a/app/assets/stylesheets/calendar_page.css
+++ b/app/assets/stylesheets/calendar_page.css
@@ -13,7 +13,7 @@
 
 .slide-posi {
   position: relative; /* 今の位置を基準 */
-  top: 75px; /* 上から10px */
+  top: 55px; /* 上から10px */
   padding-right: 20px;
 }
 

--- a/app/assets/stylesheets/tag.css
+++ b/app/assets/stylesheets/tag.css
@@ -1,0 +1,11 @@
+.tag-container {
+  display: flex; /* フレックスボックスを使って横並びにする */
+  gap: 13px; /* タグの間隔を調整 */
+  flex-wrap: wrap;
+}
+
+.tag {
+  display: flex; /* アイコンとテキストを横に並べる */
+  align-items: center; /* アイコンとテキストを中央揃えにする */
+  gap: 3px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  add_flash_types :success, :danger
 end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -6,6 +6,7 @@ class MemoriesController < ApplicationController
     start_date = params.fetch(:start_date, Date.today).to_date
     @memories = Memory.where(user_id: current_user.id, day: start_date.beginning_of_month.beginning_of_week..start_date.end_of_month.end_of_week)
     @memories_month = Memory.memories_this_month(current_user.id, start_date).order(day: :desc)
+    @tag_list = @memories_month.map(&:tags).flatten.uniq
   end
 
   def new

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -14,10 +14,10 @@ class MemoriesController < ApplicationController
 
   def create
     @memory = current_user.memories.build(memory_params)
-    if @memory.save_with_tags(tag_names: params.dig(:memory, :tag_names).split(',').uniq)
-      redirect_to memory_path(@memory), success: '思い出を記録しました'
+    if @memory.save_with_tags(tag_names: params.dig(:memory, :tag_names).split(",").uniq)
+      redirect_to memory_path(@memory), success: "思い出を記録しました"
     else
-      flash.now[:danger] = '思い出を記録できませんでした'
+      flash.now[:danger] = "思い出を記録できませんでした"
       render :new
     end
   end
@@ -46,10 +46,10 @@ class MemoriesController < ApplicationController
   def update
     @memory = current_user.memories.find(params[:id])
     @memory.assign_attributes(memory_params)
-    if @memory.save_with_tags(tag_names: params.dig(:memory, :tag_names).split(',').uniq)
-      redirect_to memory_path(@memory), success: '思い出を更新しました'
+    if @memory.save_with_tags(tag_names: params.dig(:memory, :tag_names).split(",").uniq)
+      redirect_to memory_path(@memory), success: "思い出を更新しました"
     else
-      flash.now[:danger] = '思い出を更新できませんでした'
+      flash.now[:danger] = "思い出を更新できませんでした"
       render :edit
     end
   end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -57,7 +57,7 @@ class MemoriesController < ApplicationController
   def destroy
     @memory = current_user.memories.find(params[:id])
     @memory.destroy!
-    redirect_to all_memories_path, success: '思い出を削除しました'
+    redirect_to all_memories_path, success: "思い出を削除しました"
   end
 
   def compare

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -5,9 +5,26 @@ class Memory < ApplicationRecord
 
   belongs_to :user
   has_one :post, dependent: :destroy
+  has_many :middle_tags, dependent: :destroy
+  has_many :tags, through: :middle_tags
 
   has_one_attached :main_image
   has_one_attached :sub_image
+
+  def save_with_tags(tag_names:)
+    ActiveRecord::Base.transaction do
+      self.tags = tag_names.map { |name| Tag.find_or_initialize_by(name: name.strip) }
+      save!
+    end
+    true
+  rescue StandardError
+    false
+  end
+
+  def tag_names
+    # NOTE: pluckだと新規作成失敗時に値が残らない(返り値がnilになる)
+    tags.map(&:name).join(',')
+  end
 
   scope :memories_this_month, ->(user_id, start_date) {
     where(user_id: user_id, day: start_date.beginning_of_month..start_date.end_of_month)

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -23,7 +23,7 @@ class Memory < ApplicationRecord
 
   def tag_names
     # NOTE: pluckだと新規作成失敗時に値が残らない(返り値がnilになる)
-    tags.map(&:name).join(',')
+    tags.map(&:name).join(",")
   end
 
   scope :memories_this_month, ->(user_id, start_date) {

--- a/app/models/middle_tag.rb
+++ b/app/models/middle_tag.rb
@@ -1,0 +1,6 @@
+class MiddleTag < ApplicationRecord
+  belongs_to :memory
+  belongs_to :tag
+
+  validates :tag_id, uniqueness: { scope: :memory_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :middle_tags, dependent: :destroy
+  has_many :memories, through: :middle_tags
+
+  validates :name, presence: true
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,7 @@
     <% if user_signed_in? %>
       <%= render 'shared/header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -64,6 +64,11 @@
     <div class="mb-3"><%= image_tag memory.sub_image, width: "300", height: "200" %></div>
   <% end %>
 
+  <div class="mb-3">
+    <%= f.label :tag_names %>
+    <%= f.text_field :tag_names, class: 'form-control', placeholder: ',で区切って入力してください' %>
+  </div>
+
   <div>
     <%= f.submit nil, class: "btn btn-primary mb-3" %>
   </div>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -22,6 +22,20 @@
           <%= memory.body.truncate(43) %>
         </div>
 
+        <% if memory.tags.present? %>
+          <div class="tag-container">
+            <% memory.tags.first(2).each do |tag| %>
+              <div class="tag">
+                <i class="fa-sharp fa-solid fa-tag"></i>
+                <%= tag.name.truncate(8, omission: '') %>
+              </div>
+            <% end %>
+            <% if memory.tags.size > 2 %>
+              ...
+            <% end %>
+          </div>
+        <% end %>
+
         <div class="day-pencil-trash-inner">
           <div class="text-body-secondary">
             <%= memory.day.strftime("%Y/%m/%d") %>

--- a/app/views/memories/all.html.erb
+++ b/app/views/memories/all.html.erb
@@ -13,8 +13,8 @@
       <% @tag_list.each do |tag|%>
         <div class="tag">
           <i class="fa-sharp fa-solid fa-tag"></i>
-          <%=link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
-          <%="(#{tag.memories.count})" %>
+          <%= link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
+          <%= "(#{tag.memories.count})" %>
         </div>
       <% end %>
     </div>

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -4,6 +4,20 @@
       <h2>今月の思い出の数：<%= @memories_month.count %></h2>
     </div>
 
+    <% if @tag_list.present? %>
+      <div class="tag-container">
+        <% @tag_list.each do |tag|%>
+          <div class="tag">
+            <i class="fa-sharp fa-solid fa-tag"></i>
+            <%= tag.name %>
+            : <%= "#{tag.memories.count}" %>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <br>
+    <% end %>
+
     <% if @memories_month.present? %>
       <div id="carouselExampleIndicators" class="carousel carousel-dark slide slide-posi" data-bs-ride="carousel">
         <div class="carousel-indicators">

--- a/app/views/memories/oneday.html.erb
+++ b/app/views/memories/oneday.html.erb
@@ -24,6 +24,17 @@
           </div>
         <% end %>
 
+        <% if memory.tags.present? %>
+          <div class="tag-container mb-4">
+            <% memory.tags.each do |tag| %>
+              <div class="tag">
+                <i class="fa-sharp fa-solid fa-tag"></i>
+                <%=link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+
         <div class="day-pencil-trash-inner mb-3">
           <% if memory.score.present? %>
             <% if memory.post.present? %>

--- a/app/views/memories/oneday.html.erb
+++ b/app/views/memories/oneday.html.erb
@@ -29,7 +29,7 @@
             <% memory.tags.each do |tag| %>
               <div class="tag">
                 <i class="fa-sharp fa-solid fa-tag"></i>
-                <%=link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
+                <%= link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
               </div>
             <% end %>
           </div>

--- a/app/views/memories/search_tag.html.erb
+++ b/app/views/memories/search_tag.html.erb
@@ -2,7 +2,7 @@
   <section class="py-5 text-center container">
     <div class="row py-lg-5">
       <div class="col-lg-6 col-md-8 mx-auto">
-        <h1 class="fw-light">思い出一覧</h1>
+        <h1 class="fw-light"><i class="fa-sharp fa-solid fa-tag"></i><%=@tag.name%>の思い出一覧</h1>
       </div>
     </div>
   </section>
@@ -23,13 +23,7 @@
   <div class="row">
     <div class="col-12">
       <div class="row row-cols-1 row-cols-md-2 g-4">
-        <% if @memories.present? %>
-          <%= render @memories %>
-        <% else %>
-          <div class="mb-3">
-            <h1>思い出がありません</h1>
-          </div>
-        <% end %>
+        <%= render @tag_memories %>
       </div>
     </div>
   </div>

--- a/app/views/memories/search_tag.html.erb
+++ b/app/views/memories/search_tag.html.erb
@@ -13,8 +13,8 @@
       <% @tag_list.each do |tag|%>
         <div class="tag">
           <i class="fa-sharp fa-solid fa-tag"></i>
-          <%=link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
-          <%="(#{tag.memories.count})" %>
+          <%= link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
+          <%= "(#{tag.memories.count})" %>
         </div>
       <% end %>
     </div>

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -2,7 +2,7 @@
   <div class="memory-position">
     <div class="body-style">
       <div class="mb-4 fst-italic border-bottom">
-        <h3><%= @memory.day %></h3>
+        <h3><%= @memory.day %> の思い出</h3>
       </div>
       <div class="mb-4 fst-italic border-bottom">
         <h3><%= @memory.title %></h3>
@@ -12,7 +12,7 @@
       </div>
 
       <% if @memory.score.present? %>
-        <div class="content average-score mb-5">
+        <div class="content average-score mb-4">
           <div class="star-rating mb-2">
             <div class="star-rating-front" style="width: <%= @memory.score * 20 %>%">★★★★★</div>
             <div class="star-rating-back">★★★★★</div>
@@ -20,6 +20,17 @@
           <div class="average-score-display ml-3 pt-2">
             <%= @memory.score %>/5
           </div>
+        </div>
+      <% end %>
+
+      <% if @memory.tags.present? %>
+        <div class="tag-container mb-4">
+          <% @memory.tags.each do |tag| %>
+            <div class="tag">
+              <i class="fa-sharp fa-solid fa-tag"></i>
+              <%=link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
+            </div>
+          <% end %>
         </div>
       <% end %>
 

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -28,7 +28,7 @@
           <% @memory.tags.each do |tag| %>
             <div class="tag">
               <i class="fa-sharp fa-solid fa-tag"></i>
-              <%=link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
+              <%= link_to tag.name,search_tag_memories_path(tag_id: tag.id) %>
             </div>
           <% end %>
         </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>"><%= message %></div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     collection do
       get "all"
       get "compare"
+      get "search_tag", to: "memories#search_tag"
     end
 
     resources :posts, only: %i[new create show edit update destroy]

--- a/db/migrate/20250410085443_create_tags.rb
+++ b/db/migrate/20250410085443_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[8.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :tags, :name, unique:true
+  end
+end

--- a/db/migrate/20250410085443_create_tags.rb
+++ b/db/migrate/20250410085443_create_tags.rb
@@ -6,6 +6,6 @@ class CreateTags < ActiveRecord::Migration[8.0]
       t.timestamps
     end
 
-    add_index :tags, :name, unique:true
+    add_index :tags, :name, unique: true
   end
 end

--- a/db/migrate/20250410094446_create_middle_tags.rb
+++ b/db/migrate/20250410094446_create_middle_tags.rb
@@ -6,6 +6,6 @@ class CreateMiddleTags < ActiveRecord::Migration[8.0]
 
       t.timestamps
     end
-    add_index :middle_tags, [:tag_id, :memory_id], unique: true
+    add_index :middle_tags, [ :tag_id, :memory_id ], unique: true
   end
 end

--- a/db/migrate/20250410094446_create_middle_tags.rb
+++ b/db/migrate/20250410094446_create_middle_tags.rb
@@ -1,0 +1,11 @@
+class CreateMiddleTags < ActiveRecord::Migration[8.0]
+  def change
+    create_table :middle_tags do |t|
+      t.references :memory, foreign_key: true, null: false
+      t.references :tag, foreign_key: true, null: false
+
+      t.timestamps
+    end
+    add_index :middle_tags, [:tag_id, :memory_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_08_012707) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_10_094446) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -43,13 +43,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_012707) do
   end
 
   create_table "favorites", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "post_id"
+    t.integer "user_id"
+    t.integer "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["post_id"], name: "index_favorites_on_post_id"
-    t.index ["user_id", "post_id"], name: "index_favorites_on_user_id_and_post_id", unique: true
-    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "memories", force: :cascade do |t|
@@ -64,6 +61,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_012707) do
     t.index ["user_id"], name: "index_memories_on_user_id"
   end
 
+  create_table "middle_tags", force: :cascade do |t|
+    t.bigint "memory_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["memory_id"], name: "index_middle_tags_on_memory_id"
+    t.index ["tag_id", "memory_id"], name: "index_middle_tags_on_tag_id_and_memory_id", unique: true
+    t.index ["tag_id"], name: "index_middle_tags_on_tag_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
     t.text "body", null: false
@@ -74,6 +81,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_012707) do
     t.index ["memory_id"], name: "index_posts_on_memory_id"
     t.index ["user_id", "memory_id"], name: "index_posts_on_user_id_and_memory_id", unique: true
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -91,9 +105,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_012707) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "favorites", "posts"
-  add_foreign_key "favorites", "users"
   add_foreign_key "memories", "users"
+  add_foreign_key "middle_tags", "memories"
+  add_foreign_key "middle_tags", "tags"
   add_foreign_key "posts", "memories"
   add_foreign_key "posts", "users"
 end

--- a/test/fixtures/middle_tags.yml
+++ b/test/fixtures/middle_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/middle_tag_test.rb
+++ b/test/models/middle_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MiddleTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
思い出機能にタグ機能を追加しました。

## 内容
- tagsテーブル作成
- middle_tagsテーブル作成
- ルーティング設定
- memoriesコントローラー修正、search_tagアクション追加
- 思い出記録・編集フォームにタグ追加フィールド実装
- 思い出一覧、思い出詳細ページにタグを表示
- タグをクリックしたら、そのタグを含む思い出を一覧表示させる機能実装
- フラッシュメッセージ設定