### PR TITLE
ポストにタグ機能を追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   def show
     @user = current_user
     @posts = current_user.posts.all
+    @tag_list = @posts.map(&:post_tags).flatten.uniq
   end
 
   def delete_avatar

--- a/app/models/middle_post_tag.rb
+++ b/app/models/middle_post_tag.rb
@@ -1,0 +1,6 @@
+class MiddlePostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :post_tag
+
+  validates :post_tag_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,5 +5,22 @@ class Post < ApplicationRecord
   belongs_to :user
   belongs_to :memory
 
+  has_many :middle_post_tags, dependent: :destroy
+  has_many :post_tags, through: :middle_post_tags
   has_many :favorites, dependent: :destroy
+
+  def save_with_post_tags(tag_names:)
+    ActiveRecord::Base.transaction do
+      self.post_tags = tag_names.map { |name| PostTag.find_or_initialize_by(name: name.strip) }
+      save!
+    end
+    true
+  rescue StandardError
+    false
+  end
+
+  def tag_names
+    # NOTE: pluckだと新規作成失敗時に値が残らない(返り値がnilになる)
+    post_tags.map(&:name).join(",")
+  end
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,6 @@
+class PostTag < ApplicationRecord
+  has_many :middle_post_tags, dependent: :destroy
+  has_many :posts, through: :middle_post_tags
+
+  validates :name, presence: true
+end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -32,6 +32,20 @@
           <%= post.body.truncate(43) %>
         </div>
 
+        <% if post.post_tags.present? %>
+          <div class="tag-container mb-1">
+            <% post.post_tags.first(2).each do |tag| %>
+              <div class="tag">
+                <i class="fa-sharp fa-solid fa-tag"></i>
+                <%= tag.name.truncate(8, omission: '') %>
+              </div>
+            <% end %>
+            <% if post.post_tags.size > 2 %>
+              ...
+            <% end %>
+          </div>
+        <% end %>
+
         <div class="day-pencil-trash-inner">
           <div class="text-body-secondary">
             <%= post.created_at.strftime("%Y/%m/%d") %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -14,6 +14,11 @@
           <%= f.text_area :body, class: "form-control", rows: "10" %>
         </div>
 
+        <div class="mb-3">
+          <%= f.label :tag_names %>
+          <%= f.text_field :tag_names, class: 'form-control', placeholder: ',で区切って入力してください' %>
+        </div>
+
         <%= f.submit nil, class: "btn btn-primary mb-3" %>
       <% end %>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -14,6 +14,11 @@
           <%= f.text_area :body, class: "form-control", rows: "10" %>
         </div>
 
+        <div class="mb-3">
+          <%= f.label :tag_names %>
+          <%= f.text_field :tag_names, class: 'form-control', placeholder: ',で区切って入力してください' %>
+        </div>
+
         <%= f.submit nil, class: "btn btn-primary mb-3" %>
       <% end %>
 

--- a/app/views/posts/search_mypost_tag.html.erb
+++ b/app/views/posts/search_mypost_tag.html.erb
@@ -2,7 +2,8 @@
   <section class="py-5 text-center container">
     <div class="row py-lg-5">
       <div class="col-lg-6 col-md-8 mx-auto">
-        <h1 class="fw-light">ポスト一覧</h1>
+        <h1 class="fw-light">My Post</h1>
+        <h1 class="fw-light"><i class="fa-sharp fa-solid fa-tag"></i><%=@tag.name%>のポスト一覧</h1>
       </div>
     </div>
   </section>
@@ -13,7 +14,7 @@
       <% @tag_list.each do |tag|%>
         <div class="tag">
           <i class="fa-sharp fa-solid fa-tag"></i>
-          <%= link_to tag.name,search_tag_posts_path(post_tag_id: tag.id) %>
+          <%= link_to tag.name,search_mypost_tag_posts_path(post_tag_id: tag.id) %>
           <%= "(#{tag.posts.count})" %>
         </div>
       <% end %>
@@ -23,13 +24,7 @@
   <div class="row">
     <div class="col-12">
       <div class="row row-cols-1 row-cols-md-2 g-4">
-        <% if @posts.present? %>
-          <%= render @posts %>
-        <% else %>
-          <div class="mb-3">
-            <h1>ポストがありません</h1>
-          </div>
-        <% end %>
+        <%= render @tag_posts %>
       </div>
     </div>
   </div>

--- a/app/views/posts/search_tag.html.erb
+++ b/app/views/posts/search_tag.html.erb
@@ -2,7 +2,7 @@
   <section class="py-5 text-center container">
     <div class="row py-lg-5">
       <div class="col-lg-6 col-md-8 mx-auto">
-        <h1 class="fw-light">ポスト一覧</h1>
+        <h1 class="fw-light"><i class="fa-sharp fa-solid fa-tag"></i><%=@tag.name%>のポスト一覧</h1>
       </div>
     </div>
   </section>
@@ -23,13 +23,7 @@
   <div class="row">
     <div class="col-12">
       <div class="row row-cols-1 row-cols-md-2 g-4">
-        <% if @posts.present? %>
-          <%= render @posts %>
-        <% else %>
-          <div class="mb-3">
-            <h1>ポストがありません</h1>
-          </div>
-        <% end %>
+        <%= render @tag_posts %>
       </div>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -29,9 +29,20 @@
         </div>
       <% end %>
 
-      <div class="mb-4">
+      <div class="mb-3">
         <%= render "favorites/favorite_btn", post: @post %>
       </div>
+
+      <% if @post.post_tags.present? %>
+        <div class="tag-container mb-3">
+          <% @post.post_tags.each do |tag| %>
+            <div class="tag">
+              <i class="fa-sharp fa-solid fa-tag"></i>
+              <%= link_to tag.name,search_tag_posts_path(post_tag_id: tag.id) %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
 
       <div class="day-pencil-trash-inner mb-4">
         <div class="text-body-secondary">
@@ -52,7 +63,15 @@
         <% end %>
       </div>
 
-      <%= link_to "< ポスト一覧", posts_path %>
+      <div class="mb-2">
+        <%= link_to "< ポスト一覧", posts_path %>
+      </div>
+      <% if current_user.own?(@post) %>
+        <div class="mb-2">
+          <%= link_to "< My Post一覧", users_profile_path %>
+        </div>
+        <%= link_to "< 思い出へ", memory_path(@memory) %>
+      <% end %>
     </div>
 
     <div class="image-box">

--- a/app/views/users/_my_post.html.erb
+++ b/app/views/users/_my_post.html.erb
@@ -14,7 +14,7 @@
           <% end %>
 
           <h4 class="mb-1">
-            <%= link_to post.title, memory_post_path(memory_id: post.memory_id, id: post.id) %>
+            <%= link_to post.title, memory_post_path(memory_id: post.memory_id, id: post.id), class: "no-underline" %>
           </h4>
 
           <% if post.memory.score.present? %>
@@ -33,9 +33,27 @@
             <%= post.body.truncate(43) %>
           </div>
 
+          <% if post.post_tags.present? %>
+            <div class="tag-container mb-1">
+              <% post.post_tags.first(2).each do |tag| %>
+                <div class="tag">
+                  <i class="fa-sharp fa-solid fa-tag"></i>
+                  <%= tag.name.truncate(8, omission: '') %>
+                </div>
+              <% end %>
+              <% if post.post_tags.size > 2 %>
+                ...
+              <% end %>
+            </div>
+          <% end %>
+
           <div class="day-pencil-trash-inner">
             <div class="text-body-secondary">
               <%= post.created_at.strftime("%Y/%m/%d") %>
+            </div>
+
+            <div class='ms-4'>
+              <%= render "favorites/favorite_btn", post: post %>
             </div>
 
             <% if current_user.own?(post) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -37,6 +37,20 @@
       </div>
     </div>
   </section>
+
+  タグリスト
+  <% if @tag_list.present? %>
+    <div class="tag-container mb-4">
+      <% @tag_list.each do |tag|%>
+        <div class="tag">
+          <i class="fa-sharp fa-solid fa-tag"></i>
+          <%= link_to tag.name,search_mypost_tag_posts_path(post_tag_id: tag.id) %>
+          <%= "(#{tag.posts.count})" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
   <div class="row">
     <div class="col-12">
       <div class="row row-cols-1 row-cols-md-2 g-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,11 @@ Rails.application.routes.draw do
   end
 
   resources :posts, only: %i[index] do
+    collection do
+      get "search_tag", to: "posts#search_tag"
+      get "search_mypost_tag", to: "posts#search_mypost_tag"
+    end
+
     resource :favorites, only: %i[create destroy]
   end
 end

--- a/db/migrate/20250412072904_create_post_tags.rb
+++ b/db/migrate/20250412072904_create_post_tags.rb
@@ -1,0 +1,10 @@
+class CreatePostTags < ActiveRecord::Migration[8.0]
+  def change
+    create_table :post_tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :post_tags, :name, unique: true
+  end
+end

--- a/db/migrate/20250412073003_create_middle_post_tags.rb
+++ b/db/migrate/20250412073003_create_middle_post_tags.rb
@@ -1,0 +1,11 @@
+class CreateMiddlePostTags < ActiveRecord::Migration[8.0]
+  def change
+    create_table :middle_post_tags do |t|
+      t.references :post, foreign_key: true, null: false
+      t.references :post_tag, foreign_key: true, null: false
+
+      t.timestamps
+    end
+    add_index :middle_post_tags, [ :post_tag_id, :post_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_10_094446) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_12_073003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -61,6 +61,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_10_094446) do
     t.index ["user_id"], name: "index_memories_on_user_id"
   end
 
+  create_table "middle_post_tags", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "post_tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_middle_post_tags_on_post_id"
+    t.index ["post_tag_id", "post_id"], name: "index_middle_post_tags_on_post_tag_id_and_post_id", unique: true
+    t.index ["post_tag_id"], name: "index_middle_post_tags_on_post_tag_id"
+  end
+
   create_table "middle_tags", force: :cascade do |t|
     t.bigint "memory_id", null: false
     t.bigint "tag_id", null: false
@@ -69,6 +79,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_10_094446) do
     t.index ["memory_id"], name: "index_middle_tags_on_memory_id"
     t.index ["tag_id", "memory_id"], name: "index_middle_tags_on_tag_id_and_memory_id", unique: true
     t.index ["tag_id"], name: "index_middle_tags_on_tag_id"
+  end
+
+  create_table "post_tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_post_tags_on_name", unique: true
   end
 
   create_table "posts", force: :cascade do |t|
@@ -106,6 +123,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_10_094446) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "memories", "users"
+  add_foreign_key "middle_post_tags", "post_tags"
+  add_foreign_key "middle_post_tags", "posts"
   add_foreign_key "middle_tags", "memories"
   add_foreign_key "middle_tags", "tags"
   add_foreign_key "posts", "memories"

--- a/test/fixtures/middle_post_tags.yml
+++ b/test/fixtures/middle_post_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/middle_post_tag_test.rb
+++ b/test/models/middle_post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MiddlePostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
ポストにタグ機能を追加しました。

## 内容
- post_tagsテーブル作成
- middle_post_tagsテーブル作成
- ルーティング設定
- postsコントローラー修正、search_tagアクション追加、search_mypost_tagアクション追加
- ポスト作成・編集フォームにタグ追加フィールド実装
- ポスト一覧、ポスト詳細、プロフィールページにタグを表示
- タグをクリックしたら、そのタグを含むポストを一覧表示させる機能実装