### PR TITLE
画像の表示サイズ・トリミング修正

### DIFF
--- a/app/assets/stylesheets/calendar_page.css
+++ b/app/assets/stylesheets/calendar_page.css
@@ -16,6 +16,11 @@
   position: relative; /* 今の位置を基準 */
 }
 
+.carousel-main-image img {
+  object-fit: contain;
+  height: 535px;
+}
+
 .image-text {
   text-anchor: middle;
   text-align: center;
@@ -75,7 +80,7 @@
   }
 
   .carousel-main-image img {
-    height: 500px;
+    height: 550px;
   }
 }
 
@@ -103,7 +108,7 @@
   }
 
   .carousel-main-image img {
-    height: 250px;
+    height: 290px;
   }
 
   .day-title-style {

--- a/app/assets/stylesheets/memories.css
+++ b/app/assets/stylesheets/memories.css
@@ -3,6 +3,10 @@
   padding-bottom: 3rem;
 }
 
+.main-image-style {
+  object-fit: cover;
+}
+
 .compare-title {
   padding-top: 2rem;
 }

--- a/app/assets/stylesheets/memory.css
+++ b/app/assets/stylesheets/memory.css
@@ -59,13 +59,17 @@
   box-sizing: border-box;
   width: 60%;
   margin: 70px 0px 20px 0px;
-  display: flex;
   justify-content: center;
   padding-left: 20px;
 }
 
 .image-pozi {
   float:left;
+}
+
+.carousel-show-image img {
+  height: 680px;
+  object-fit: contain;
 }
 
 .right{
@@ -83,13 +87,13 @@
 
   .body-style {
     width: 100%;
-    margin: 30px 0px 10px 0px;
+    margin: 30px 0px 0px 0px;
   }
 
   .image-box {
     width: 100%;
     text-align: center;
-    margin: 10px 0px 20px 0px;
+    margin: 20px 0px 20px 0px;
     padding-left: 0px;
   }
 
@@ -105,11 +109,11 @@
 @media (max-width: 450px) {
   .body-style {
     width: 100%;
-    margin: 20px 0px 10px 0px;
+    margin: 20px 0px 0px 0px;
   }
 
   .carousel-show-image img {
-    height: auto;
+    height: 380px;
   }
 
   .memory-style {

--- a/app/assets/stylesheets/profile.css
+++ b/app/assets/stylesheets/profile.css
@@ -8,6 +8,10 @@
   height: 200px;
 }
 
+.avatar-style{
+  object-fit: cover;
+}
+
 .pf-bottom {
   margin-bottom: 2rem;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -62,7 +62,8 @@ class PostsController < ApplicationController
   end
 
   def search_tag
-    @tag_list = PostTag.all
+    @posts=Post.order(created_at: :desc)
+    @tag_list = @posts.map(&:post_tags).flatten.uniq
     @tag = PostTag.find(params[:post_tag_id])
     @tag_posts = @tag.posts
   end

--- a/app/views/memories/_form.html.erb
+++ b/app/views/memories/_form.html.erb
@@ -48,22 +48,32 @@
 
   <div class="mb-3">
     <%= f.label :main_image %>
-    <%= f.file_field :main_image, class: "form-control", accept: 'image/*' %>
+    <%= f.file_field :main_image, onchange: "mainImage(this);", class: "form-control", accept: 'image/*' %>
+  </div>
+
+  <div id="main_image" style="display:none;" class="mb-4" >
+    <span>選択したメイン画像</span><br />
+    <img id="main_image_preview" width="250">
   </div>
 
   <% if memory.persisted? && memory.main_image.present? %>
-    <a>登録済み画像<a>
-    <div class="mb-3"><%= image_tag memory.main_image, width: "300", height: "200" %></div>
+    <a>登録済みメイン画像<a>
+    <div class="mb-4"><%= image_tag memory.main_image, width: "250" %></div>
   <% end %>
 
   <div class="mb-3">
     <%= f.label :sub_image %>
-    <%= f.file_field :sub_image, class: "form-control", accept: 'image/*' %>
+    <%= f.file_field :sub_image, onchange: "subImage(this);", class: "form-control", accept: 'image/*' %>
+  </div>
+
+  <div id="sub_image" style="display:none;" class="mb-4" >
+    <span>選択したサブ画像</span><br />
+    <img id="sub_image_preview" width="250">
   </div>
 
   <% if memory.persisted? && memory.sub_image.present? %>
-    <a>登録済み画像<a>
-    <div class="mb-3"><%= image_tag memory.sub_image, width: "300", height: "200" %></div>
+    <a>登録済みサブ画像<a>
+    <div class="mb-4"><%= image_tag memory.sub_image, width: "250" %></div>
   <% end %>
 
   <div class="mb-3">
@@ -75,3 +85,35 @@
 <% end %>
 
 <%= javascript_include_tag "rating.js" %>
+
+<script>
+  function mainImage(obj){
+    var fileReader = new FileReader();
+    var avatarDiv = document.getElementById('main_image');
+
+    if (obj.files && obj.files[0]) {
+      fileReader.onload = (function() {
+        document.getElementById('main_image_preview').src = fileReader.result; // プレビューに画像を設定
+        avatarDiv.style.display = 'block'; // プレビューを表示
+      });
+      fileReader.readAsDataURL(obj.files[0]); // 画像ファイルを読み込む
+    } else {
+      avatarDiv.style.display = 'none'; // 画像が選択されていない場合は非表示
+    }
+  }
+
+  function subImage(obj){
+    var fileReader = new FileReader();
+    var avatarDiv = document.getElementById('sub_image');
+
+    if (obj.files && obj.files[0]) {
+      fileReader.onload = (function() {
+        document.getElementById('sub_image_preview').src = fileReader.result; // プレビューに画像を設定
+        avatarDiv.style.display = 'block'; // プレビューを表示
+      });
+      fileReader.readAsDataURL(obj.files[0]); // 画像ファイルを読み込む
+    } else {
+      avatarDiv.style.display = 'none'; // 画像が選択されていない場合は非表示
+    }
+  }
+</script>

--- a/app/views/memories/_main_images.html.erb
+++ b/app/views/memories/_main_images.html.erb
@@ -2,9 +2,9 @@
   <% if i == 0 %>
     <div class="carousel-item active carousel-main-image">
       <% if memory.main_image.present? %>
-        <%= image_tag memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "500", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+        <%= image_tag memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
       <% else %>
-        <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "500", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+        <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
       <% end %>
       <div class="carousel-caption d-md-block">
         <%= link_to "#{memory.day.strftime("%Y/%m/%d")} - #{memory.title}", memory_path(memory), class: "day-title-box day-title-style" %>
@@ -13,9 +13,9 @@
   <% else %>
     <div class="carousel-item carousel-main-image">
       <% if memory.main_image.present? %>
-        <%= image_tag memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "500", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+        <%= image_tag memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
       <% else %>
-        <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "500", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+        <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
       <% end %>
       <div class="carousel-caption d-md-block">
         <%= link_to "#{memory.day.strftime("%Y/%m/%d")} - #{memory.title}", memory_path(memory), class: "day-title-box day-title-style" %>

--- a/app/views/memories/_memory.html.erb
+++ b/app/views/memories/_memory.html.erb
@@ -1,9 +1,9 @@
 <div class="col mb-4">
   <div id="memory-id-<%= memory.id %>">
     <% if memory.main_image.present? %>
-      <%= link_to image_tag(memory.main_image, class: "bd-placeholder-img rounded-top border-top border-end border-start", width: "100%", height: "245", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_path(memory) %>
+      <%= link_to image_tag(memory.main_image, class: "bd-placeholder-img rounded-top border-top border-end border-start main-image-style", width: "100%", height: "245", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_path(memory) %>
     <% else %>
-      <%= link_to image_tag("no_image.png", class: "bd-placeholder-img rounded-top border-top border-end border-start", width: "100%", height: "245", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_path(memory) %>
+      <%= link_to image_tag("no_image.png", class: "bd-placeholder-img rounded-top border-top border-end border-start main-image-style", width: "100%", height: "245", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_path(memory) %>
     <% end %>
 
     <div class="g-0 rounded-bottom border-end border-start shadow-sm overflow-hidden flex-md-row h-md-250 position-relative memory-coloe memory-style">

--- a/app/views/memories/oneday.html.erb
+++ b/app/views/memories/oneday.html.erb
@@ -91,13 +91,13 @@
           <div class="carousel-inner">
             <div class="carousel-item active carousel-show-image">
               <% if memory.main_image.present? %>
-                <%= image_tag memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+                <%= image_tag memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
               <% else %>
-                <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+                <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
               <% end %>
             </div>
             <div class="carousel-item  carousel-show-image">
-              <%= image_tag memory.sub_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+              <%= image_tag memory.sub_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
             </div>
           </div>
           <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="prev">
@@ -115,9 +115,9 @@
           <div class="carousel-inner">
             <div class="carousel-item active carousel-show-image">
               <% if memory.main_image.present? %>
-                <%= image_tag memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+                <%= image_tag memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
               <% else %>
-                <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+                <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
               <% end %>
             </div>
           </div>

--- a/app/views/memories/show.html.erb
+++ b/app/views/memories/show.html.erb
@@ -89,13 +89,13 @@
         <div class="carousel-inner">
           <div class="carousel-item active carousel-show-image">
             <% if @memory.main_image.present? %>
-              <%= image_tag @memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+              <%= image_tag @memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
             <% else %>
-              <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+              <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
             <% end %>
           </div>
           <div class="carousel-item carousel-show-image">
-            <%= image_tag @memory.sub_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+            <%= image_tag @memory.sub_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
           </div>
         </div>
         <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="prev">
@@ -113,9 +113,9 @@
         <div class="carousel-inner">
           <div class="carousel-item active carousel-show-image">
             <% if @memory.main_image.present? %>
-              <%= image_tag @memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+              <%= image_tag @memory.main_image, class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
             <% else %>
-              <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", width: "800", height: "690", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
+              <%= image_tag "no_image.png", class: "bd-placeholder-img bd-placeholder-img-lg d-block w-100", xmlns: "http://www.w3.org/2000/svg", role: "img", preserveAspectRatio: "xMidYMid slice", focusable: "false" %>
             <% end %>
           </div>
         </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,20 +1,20 @@
 <div class="col mb-4">
   <div id="post-id-<%= post.id %>">
     <% if post.memory.main_image.present? %>
-      <%= link_to image_tag(post.memory.main_image, class: "bd-placeholder-img rounded-top border-top border-end border-start", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
+      <%= link_to image_tag(post.memory.main_image, class: "bd-placeholder-img rounded-top border-top border-end border-start main-image-style", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
     <% else %>
-      <%= link_to image_tag("no_image.png", class: "bd-placeholder-img rounded-top border-top border-end border-start", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
+      <%= link_to image_tag("no_image.png", class: "bd-placeholder-img rounded-top border-top border-end border-start main-image-style", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
     <% end %>
 
     <div class="g-0 border-end border-start shadow-sm overflow-hidden flex-md-row h-md-250 position-relative memory-coloe post-style">
       <div class="col post-p flex-column position-static">
         <% if post.user.avatar.attached? %>
           <div class="mb-1 pb-1 user-style">
-            <%= image_tag post.user.avatar, class: "rounded-circle", alt: "mdo", width: '35', height: '35'  %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
+            <%= image_tag post.user.avatar, class: "rounded-circle avatar-style", alt: "mdo", width: '35', height: '35'  %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
           </div>
         <% else %>
           <div class="mb-1 pb-1 user-style">
-            <%= image_tag "icon.png", class: "rounded-circle", alt: "mdo", width: '35', height: '35' %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
+            <%= image_tag "icon.png", class: "rounded-circle avatar-style", alt: "mdo", width: '35', height: '35' %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
           </div>
         <% end %>
 

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -29,9 +29,9 @@
           <div  class="image-posi">
             <div class="mb-1">※表示される画像（思い出のメイン画像）</div>
             <% if @memory.main_image.present? %>
-              <%= image_tag @memory.main_image, width: "300", height: "200" %>
+              <%= image_tag @memory.main_image, width: "250" %>
             <% else %>
-              <%= image_tag "no_image.png", width: "300", height: "200" %>
+              <%= image_tag "no_image.png", width: "250" %>
             <% end %>
           </div>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -29,9 +29,9 @@
           <div  class="image-posi">
             <div class="mb-1">※表示される画像（思い出のメイン画像）</div>
             <% if @memory.main_image.present? %>
-              <%= image_tag @memory.main_image, width: "300", height: "200" %>
+              <%= image_tag @memory.main_image, width: "250" %>
             <% else %>
-              <%= image_tag "no_image.png", width: "300", height: "200" %>
+              <%= image_tag "no_image.png", width: "250" %>
             <% end %>
           </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -26,9 +26,9 @@
         <div class='dropdown user-icon'>
           <%= link_to '#', class: "d-block link-body-emphasis text-decoration-none show", data: { bs_toggle: 'dropdown' }, aria: { expanded: 'true' } do %>
             <% if current_user.avatar.attached? %>
-              <%= image_tag current_user.avatar, class: "rounded-circle", alt: "mdo", width: '45', height: '45' %><span class="user-icon-name ms-1"><%= current_user.name %></span>
+              <%= image_tag current_user.avatar, class: "rounded-circle avatar-style", alt: "mdo", width: '45', height: '45' %><span class="user-icon-name ms-1"><%= current_user.name %></span>
             <% else %>
-              <%= image_tag "icon.png", class: "rounded-circle", width: '45', height: '45' %><span class="user-icon-name ms-1"><%= current_user.name %></span>
+              <%= image_tag "icon.png", class: "rounded-circle avatar-style", width: '45', height: '45' %><span class="user-icon-name ms-1"><%= current_user.name %></span>
             <% end %>
           <% end %>
           <div class='dropdown-menu'>

--- a/app/views/users/_favorite_posts.html.erb
+++ b/app/views/users/_favorite_posts.html.erb
@@ -2,20 +2,20 @@
   <div class="col mb-4">
     <div id="post-id-<%= post.id %>">
       <% if post.memory.main_image.present? %>
-        <%= link_to image_tag(post.memory.main_image, class: "bd-placeholder-img rounded-top border-top border-end border-start", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
+        <%= link_to image_tag(post.memory.main_image, class: "bd-placeholder-img rounded-top border-top border-end border-start main-image-style", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
       <% else %>
-        <%= link_to image_tag("no_image.png", class: "bd-placeholder-img rounded-top border-top border-end border-start", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
+        <%= link_to image_tag("no_image.png", class: "bd-placeholder-img rounded-top border-top border-end border-start main-image-style", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
       <% end %>
 
       <div class="g-0 border-end border-start shadow-sm overflow-hidden flex-md-row h-md-250 position-relative memory-coloe post-style">
         <div class="col post-p flex-column position-static">
           <% if post.user.avatar.attached? %>
             <div class="mb-1 pb-1 user-style">
-              <%= image_tag post.user.avatar, class: "rounded-circle", alt: "mdo", width: '35', height: '35'  %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
+              <%= image_tag post.user.avatar, class: "rounded-circle avatar-style", alt: "mdo", width: '35', height: '35'  %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
             </div>
           <% else %>
             <div class="mb-1 pb-1 user-style">
-              <%= image_tag "icon.png", class: "rounded-circle", alt: "mdo", width: '35', height: '35' %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
+              <%= image_tag "icon.png", class: "rounded-circle avatar-style", alt: "mdo", width: '35', height: '35' %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
             </div>
           <% end %>
 

--- a/app/views/users/_my_post.html.erb
+++ b/app/views/users/_my_post.html.erb
@@ -2,20 +2,20 @@
   <div class="col mb-4">
     <div id="post-id-<%= post.id %>">
       <% if post.memory.main_image.present? %>
-        <%= link_to image_tag(post.memory.main_image, class: "bd-placeholder-img rounded-top border-top border-end border-start", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
+        <%= link_to image_tag(post.memory.main_image, class: "bd-placeholder-img rounded-top border-top border-end border-start main-image-style", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
       <% else %>
-        <%= link_to image_tag("no_image.png", class: "bd-placeholder-img rounded-top border-top border-end border-start", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
+        <%= link_to image_tag("no_image.png", class: "bd-placeholder-img rounded-top border-top border-end border-start main-image-style", width: "100%", height: "250", xmlns: "http://www.w3.org/2000/svg", role: "img",  preserveAspectRatio: "xMidYMid slice", focusable: "false"), memory_post_path(memory_id: post.memory_id, id: post.id) %>
       <% end %>
 
       <div class="g-0 border-end border-start shadow-sm overflow-hidden flex-md-row h-md-250 position-relative memory-coloe post-style">
         <div class="col post-p flex-column position-static">
           <% if post.user.avatar.attached? %>
             <div class="mb-1 pb-1 user-style">
-              <%= image_tag post.user.avatar, class: "rounded-circle", alt: "mdo", width: '35', height: '35'  %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
+              <%= image_tag post.user.avatar, class: "rounded-circle avatar-style", alt: "mdo", width: '35', height: '35'  %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
             </div>
           <% else %>
             <div class="mb-1 pb-1 user-style">
-              <%= image_tag "icon.png", class: "rounded-circle", alt: "mdo", width: '35', height: '35' %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
+              <%= image_tag "icon.png", class: "rounded-circle avatar-style", alt: "mdo", width: '35', height: '35' %><span class="name_style title-limit ms-1"><%= post.user.name %></span>
             </div>
           <% end %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -22,12 +22,12 @@
 
         <div id="avatar" style="display:none;" class="mb-4" >
           <span>選択したアバター画像</span><br />
-          <img id="avatar_preview" class="rounded-circle" width="150" height="150">
+          <img id="avatar_preview" class="rounded-circle avatar-style" width="150" height="150">
         </div>
 
         <% if @user.avatar.attached? %>
           <span>登録済みアバター画像</span><br />
-          <%= image_tag @user.avatar, class: "rounded-circle mb-3", width: '150', height: '150' %>
+          <%= image_tag @user.avatar, class: "rounded-circle avatar-style mb-3", width: '150', height: '150' %>
         <% end %>
 
         <div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,9 +5,9 @@
     <div class="row pf-style">
       <div class="col-lg-6 col-md-8 mx-auto">
         <% if @user.avatar.attached? %>
-          <%= image_tag @user.avatar, class: "rounded-circle pf-bottom avatar-size" %>
+          <%= image_tag @user.avatar, class: "rounded-circle pf-bottom avatar-size avatar-style" %>
         <% else %>
-          <%= image_tag "icon.png", class: "rounded-circle pf-bottom avatar-size" %>
+          <%= image_tag "icon.png", class: "rounded-circle pf-bottom avatar-size avatar-style" %>
         <% end %>
 
         <div class="pf-bottom">


### PR DESCRIPTION
## 内容
- カレンダーページ、思い出詳細ページ、ポスト詳細ページの画像の表示サイズとトリミングを修正しました。
- 思い出一覧ページ、ポスト一覧ページの画像のトリミングを修正しました。
- 思い出記録・編集フォームで画像を選択した場合、その画像をプレビュー表示させるように修正しました。
- ポスト作成・編集ページの画像の表示サイズを修正しました。